### PR TITLE
fix: Make default Metal shader library

### DIFF
--- a/intern/cycles/device/device_metal.mm
+++ b/intern/cycles/device/device_metal.mm
@@ -52,9 +52,8 @@ private:
     // TODO: grab the specific device that was asked for
     metalDevice = MTLCreateSystemDefaultDevice();
     commandQueue = [metalDevice newCommandQueue];
-    NSURL *libURL = [NSBundle.mainBundle URLForResource:@"Shaders" withExtension:@"metallib"];
     NSError *error;
-    id<MTLLibrary> lib = [metalDevice newLibraryWithURL:libURL error:&error];
+    id<MTLLibrary> lib = [metalDevice newDefaultLibraryWithBundle:NSBundle.mainBundle error:&error];
     library = lib;
 
     setupPipelines();


### PR DESCRIPTION
Use the method `newDefaultLibraryWithBundle` to create a default Metal shader library out of all Metal files instead of using one very specific library

My Xcode project might not be configured correctly, but with this fix I am not getting a `SIGABRT` when creating the Metal library that I get when calling `newLibraryWithURL`. Additionally, `newDefaultLibraryWithBundle` is available in macOS 10.11+ while `newLibraryWithURL` requires macOS 10.13.